### PR TITLE
Issue 1100 :  Filename too long solution for Windows.

### DIFF
--- a/docs/developer-guide/building-the-code.md
+++ b/docs/developer-guide/building-the-code.md
@@ -78,7 +78,7 @@ The reason for this failure is that OrientDB can't start, if another OrientDB pr
 If you hit an error like:
 
 ```
-    error: unable to create file strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-    metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/MetadataVersionComparator.java: Filename too long
+error: unable to create file strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/MetadataVersionComparator.java: Filename too long
 ```
 
 You will need to execute the following command:

--- a/docs/developer-guide/building-the-code.md
+++ b/docs/developer-guide/building-the-code.md
@@ -73,16 +73,21 @@ Then please make sure that:
 
 The reason for this failure is that OrientDB can't start, if another OrientDB process is running an listening on the same port.
 
-### Filename too long
+### Filename too long (Windows 7 and 10)
 
-If you see something like this:
+If you hit an error like:
 
+```
     error: unable to create file strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-    metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/MetadataVersionComparator.java: Filename too long
+```
 
-Then Open the Github Powershell or cmd.exe (you need to have git as an environment variable) and execute the following command :
-```git config --system core.longpaths true```
+You will need to execute the following command:
 
-The change should be executed immediately and you can procceed with the build.
+```
+git config --system core.longpaths true
+```
+
+At this point, you should be able to `git clone` the project properly under Windows and procceed with the build.
 
 ## Spring Boot
 

--- a/docs/developer-guide/building-the-code.md
+++ b/docs/developer-guide/building-the-code.md
@@ -12,7 +12,6 @@ mvn clean install
 
 If (and only if) this does not work out of the box, then you might have to build and install the following projects 
 using `mvn clean install` in the order they are listed below:
-
 1. [unboundid-maven-plugin](https://github.com/carlspring/unboundid-maven-plugin)
 2. [little-proxy-maven-plugin](https://github.com/carlspring/little-proxy-maven-plugin)
 3. [maven-commons](https://github.com/carlspring/maven-commons/)

--- a/docs/developer-guide/building-the-code.md
+++ b/docs/developer-guide/building-the-code.md
@@ -37,6 +37,7 @@ To execute a particular tests, run:
 
 To execute a test method of a test, run:
 
+
     mvn clean install -Dtest=MyTest#testMyMethod
 
 ### Executing the tests in remote debug mode
@@ -72,6 +73,17 @@ Then please make sure that:
 * You don't have any other test in progress (e.g. halted by debugger process)
 
 The reason for this failure is that OrientDB can't start, if another OrientDB process is running an listening on the same port.
+
+### Filename too long
+
+If you see something like this:
+
+    error: unable to create file strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-    metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/MetadataVersionComparator.java: Filename too long
+
+Then Open the Github Powershell or cmd.exe (you need to have git as an environment variable) and execute the following command :
+```git config --system core.longpaths true```
+
+The change should be executed immediately and you can procceed with the build.
 
 ## Spring Boot
 


### PR DESCRIPTION
Added the solution in documents.

Windows 10 workaround for strongbox/strongbox#1100.
