### PR TITLE
Adds MacOS install docs

### DIFF
--- a/docs/assets/resources/launchctl/strongbox.plist
+++ b/docs/assets/resources/launchctl/strongbox.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Disabled</key>
+    <false/>
+    <key>Label</key>
+    <string>strongbox</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/strongbox/bin/strongbox</string>
+        <string>console</string>
+    </array>
+    <key>UserName</key>
+    <string>strongbox</string>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -77,9 +77,10 @@ tar -zxf /path/to/strongbox-distribution*.tar.gz \
 # plist file. If you've customized the installation, edit the details
 # in the plist file where necessary.
 # (This file must be owned by root.)
-sudo curl -o /opt/strongbox/etc/strongbox.plist \
+sudo curl -o /Library/LaunchDaemons/strongbox.plist \
      https://strongbox.github.io/assets/resources/launchctl/strongbox.plist
 
+# This will validate that launchd can load the file and start the service.
 sudo launchctl load /opt/strongbox/etc/strongbox.plist
 
 # Strongbox will now start on boot.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -56,6 +56,36 @@ c:\java\strongbox> bin\strongbox.bat start
 
 ```
 
+```MacOS linenums="1" tab=
+# Open a terminal
+
+sudo su
+sysadminctl -addUser strongbox
+mkdir -p /opt/{strongbox,strongbox-vault}
+chown -R strongbox:staff /opt/{strongbox,strongbox-vault}
+chmod -R 770 /opt/{strongbox,strongbox-vault}
+su strongbox
+tar -zxf /path/to/strongbox-distribution*.tar.gz \
+    -C /opt/strongbox \ 
+    --strip-components=2
+
+# If you just want to start Strongbox without installing the launchctl service:
+
+/opt/strongbox/bin/strongbox console
+
+# If you want to install Strongbox as a LaunchDaemon then download the 
+# plist file. If you've customized the installation, edit the details
+# in the plist file where necessary.
+# (This file must be owned by root.)
+sudo curl -o /opt/strongbox/etc/strongbox.plist \
+     https://strongbox.github.io/assets/resources/launchctl/strongbox.plist
+
+sudo launchctl load /opt/strongbox/etc/strongbox.plist
+
+# Strongbox will now start on boot.
+
+```
+
 ```Docker linenums="1" tab=
 
 Currently unavailable due to our heavy development.
@@ -66,6 +96,3 @@ use `docker-compose up` instead.
 ```
 
 
-!!! info "Help wanted!"
-
-    We would like to add instructions for MacOS. If you're interested in giving us a hand, please have a look at <a href="https://github.com/strongbox/strongbox/issues/1008">strongbox/strongbox#1008</a>

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -33,7 +33,7 @@ tar -zxf /path/to/strongbox-distribution*.tar.gz \
 # and load that instead.
 
 sudo curl -o /etc/systemd/system/strongbox.service \
-     https://strongbox.github.io/assets/resources/systemd/strongbox.service 
+     {{resources}}/systemd/strongbox.service 
 sudo systemctl deamon-reload
 sudo service strongbox start
 
@@ -78,7 +78,7 @@ tar -zxf /path/to/strongbox-distribution*.tar.gz \
 # in the plist file where necessary.
 # (This file must be owned by root.)
 sudo curl -o /Library/LaunchDaemons/strongbox.plist \
-     https://strongbox.github.io/assets/resources/launchctl/strongbox.plist
+     {{resources}}/launchctl/strongbox.plist
 
 # This will validate that launchd can load the file and start the service.
 sudo launchctl load /opt/strongbox/etc/strongbox.plist


### PR DESCRIPTION
Following testing of the distribution as requested in https://github.com/strongbox/strongbox/issues/1008 , updated docs as follows:

- Added installation instructions on MacOS using the tar file distribution.
- Created plist file so that `launchd` can start Strongbox at system boot.