### PR TITLE
Update getting-started.md Mac and Linux sections

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -14,11 +14,19 @@
 # Open a terminal
 
 sudo su
-mkdir /opt/{strongbox,strongbox-vault}
+
+mkdir /opt/strongbox
+mkdir /opt/strongbox-vault
+
 groupadd strongbox
 useradd -d /opt/strongbox -g strongbox -r strongbox
-chown -R strongbox:strongbox /opt/{strongbox,strongbox-vault}
-chmod -R 770 /opt/{strongbox,strongbox-vault}
+
+chown -R strongbox:strongbox /opt/strongbox
+chown -R strongbox:strongbox /opt/strongbox-vault
+
+chmod -R 770 /opt/strongbox
+chmod -R 770 /opt/strongbox-vault
+
 su strongbox
 tar -zxf /path/to/strongbox-distribution*.tar.gz \
     -C /opt/strongbox \ 
@@ -63,9 +71,16 @@ c:\java\strongbox> bin\strongbox.bat start
 
 sudo su
 sysadminctl -addUser strongbox
-mkdir -p /opt/{strongbox,strongbox-vault}
-chown -R strongbox:staff /opt/{strongbox,strongbox-vault}
-chmod -R 770 /opt/{strongbox,strongbox-vault}
+
+mkdir -p /opt/strongbox
+mkdir -p /opt/strongbox-vault
+
+chown -R strongbox:staff /opt/strongbox
+chown -R strongbox:staff /opt/strongbox-vault
+
+chmod -R 770 /opt/strongbox
+chmod -R 770 /opt/strongbox-vault
+
 su strongbox
 tar -zxf /path/to/strongbox-distribution*.tar.gz \
     -C /opt/strongbox \ 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -15,17 +15,14 @@
 
 sudo su
 
-mkdir /opt/strongbox
-mkdir /opt/strongbox-vault
+mkdir /opt/strongbox /opt/strongbox-vault
 
 groupadd strongbox
 useradd -d /opt/strongbox -g strongbox -r strongbox
 
-chown -R strongbox:strongbox /opt/strongbox
-chown -R strongbox:strongbox /opt/strongbox-vault
+chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
 
-chmod -R 770 /opt/strongbox
-chmod -R 770 /opt/strongbox-vault
+chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
 su strongbox
 tar -zxf /path/to/strongbox-distribution*.tar.gz \
@@ -72,14 +69,11 @@ c:\java\strongbox> bin\strongbox.bat start
 sudo su
 sysadminctl -addUser strongbox
 
-mkdir -p /opt/strongbox
-mkdir -p /opt/strongbox-vault
+mkdir -p /opt/strongbox /opt/strongbox-vault
 
-chown -R strongbox:staff /opt/strongbox
-chown -R strongbox:staff /opt/strongbox-vault
+chown -R strongbox:staff /opt/strongbox /opt/strongbox-vault
 
-chmod -R 770 /opt/strongbox
-chmod -R 770 /opt/strongbox-vault
+chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
 su strongbox
 tar -zxf /path/to/strongbox-distribution*.tar.gz \


### PR DESCRIPTION
Brace expansion don't work in `dash` and doing `mkdir /opt/{strongbox,strongbox-vault}` would result in a directory literally called `{strongbox, strongbox-vault}`. This is something which would happen on `Debian` and `ArchLinux` for example as their default `/bin/sh` is actually `dash`.

Brace expansion should work in Mac, but we're choosing to be safe than sorry.

// @steve-todorov 