### PR TITLE
Update docs with instructions for using RPM distribution

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -8,7 +8,7 @@
 
 <a href="https://github.com/strongbox/strongbox/releases" target="_blank">Download strongbox</a>
 
-```Linux linenums="1" tab=
+```Linux (tar) linenums="1" tab=
 # Open a terminal
 
 sudo su
@@ -39,6 +39,22 @@ sudo service strongbox start
 
 # this step is optional: only if you want to start Strongbox at boot!
 sudo systemctl enable strongbox
+```
+
+```Linux (RPM) linenums="1" tab=
+# Open a terminal
+
+sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
+
+# If you just want to start Strongbox without installing the systemd service:
+su strongbox
+/opt/strongbox/bin/strongbox console
+
+# If you want to configure strongbox to start at system, boot:
+
+sudo systemctl enable strongbox.service
+sudo service strongbox start
+
 ```
 
 ```Windows linenums="1" tab=

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -44,6 +44,10 @@ sudo systemctl enable strongbox
 ```Linux (RPM) linenums="1" tab=
 # Open a terminal
 
+# First, make sure you have a JRE with version 1.8 or greater
+# installed on your system.  You can use your favorite package manager
+# to find one.
+
 sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
 
 # If you just want to start Strongbox without installing the systemd service:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -8,7 +8,7 @@
 
 <a href="https://github.com/strongbox/strongbox/releases" target="_blank">Download strongbox</a>
 
-```Linux (tar) linenums="1" tab=
+```linuxtar linenums="1" tab="Linux (tar)"
 # Open a terminal
 
 sudo su
@@ -41,7 +41,7 @@ sudo service strongbox start
 sudo systemctl enable strongbox
 ```
 
-```Linux (RPM) linenums="1" tab=
+```linuxrpm linenums="1" tab="Linux (RPM)"
 # Open a terminal
 
 # First, make sure you have a JRE with version 1.8 or greater


### PR DESCRIPTION
This fixes https://github.com/strongbox/strongbox/issues/1151 by adding a documentation section for using the RPM distribution.