### PR TITLE
Add @TempDir annotation usage for JUnit 5.

### DIFF
--- a/docs/developer-guide/junit-user-guide.md
+++ b/docs/developer-guide/junit-user-guide.md
@@ -239,7 +239,8 @@ A new feature in JUnit 5 which allows us to repeat a test in a specified number 
 
 ```java
 @RepeatedTest(100)
-void repeatedTest() {
+void repeatedTest()
+{
     // ...
 }
 ``` 
@@ -250,7 +251,8 @@ Let’s see an example which we generate 2 tests at runtime:
 
 ```java
 @TestFactory
-Collection<DynamicTest> dynamicTestsFromCollection() {
+Collection<DynamicTest> dynamicTestsFromCollection()
+{
     return Arrays.asList(
         dynamicTest("1st dynamic test", () -> assertTrue(true)),
         dynamicTest("2nd dynamic test", () -> assertEquals(4, 2 * 2))
@@ -265,7 +267,8 @@ For example, the following test declares a parameter annotated with `@TempDir` f
 
 ```java
 @Test
-void writeItemsToFile(@TempDir Path tempDir) throws IOException {
+void writeItemsToFile(@TempDir Path tempDir) throws IOException
+{
     Path file = tempDir.resolve("test.txt");
 
     new ListWriter(file).write("a", "b", "c");
@@ -277,13 +280,15 @@ void writeItemsToFile(@TempDir Path tempDir) throws IOException {
 The following example stores a shared temporary directory in a `static` field. This allows the same `sharedTempDir` to be used in all lifecycle methods and test methods of the test class.
 
 ```java
-class SharedTempDirectoryDemo {
+class SharedTempDirectoryDemo
+{
 
     @TempDir
     static Path sharedTempDir;
 
     @Test
-    void writeItemsToFile() throws IOException {
+    void writeItemsToFile() throws IOException
+    {
         Path file = sharedTempDir.resolve("test.txt");
 
         new ListWriter(file).write("a", "b", "c");
@@ -292,7 +297,8 @@ class SharedTempDirectoryDemo {
     }
 
     @Test
-    void anotherTestThatUsesTheSameTempDir() {
+    void anotherTestThatUsesTheSameTempDir()
+    {
         // use sharedTempDir
     }
 

--- a/docs/developer-guide/junit-user-guide.md
+++ b/docs/developer-guide/junit-user-guide.md
@@ -257,3 +257,44 @@ Collection<DynamicTest> dynamicTestsFromCollection() {
     );
 }
 ``` 
+
+## Temp directories
+The `@TempDir` annotation is used to create and clean up a temporary directory for an individual test or all tests in a test class. To use it, annotate a non-private field of type `java.nio.file.Path` or `java.io.File` with `@TempDir` or add a parameter of type `java.nio.file.Path` or `java.io.File` annotated with `@TempDir` to a lifecycle method or test method.
+
+For example, the following test declares a parameter annotated with `@TempDir` for a single test method, creates and writes to a file in the temporary directory, and checks its content.
+
+```java
+@Test
+void writeItemsToFile(@TempDir Path tempDir) throws IOException {
+    Path file = tempDir.resolve("test.txt");
+
+    new ListWriter(file).write("a", "b", "c");
+
+    assertEquals(singletonList("a,b,c"), Files.readAllLines(file));
+}
+``` 
+
+The following example stores a shared temporary directory in a `static` field. This allows the same `sharedTempDir` to be used in all lifecycle methods and test methods of the test class.
+
+```java
+class SharedTempDirectoryDemo {
+
+    @TempDir
+    static Path sharedTempDir;
+
+    @Test
+    void writeItemsToFile() throws IOException {
+        Path file = sharedTempDir.resolve("test.txt");
+
+        new ListWriter(file).write("a", "b", "c");
+
+        assertEquals(singletonList("a,b,c"), Files.readAllLines(file));
+    }
+
+    @Test
+    void anotherTestThatUsesTheSameTempDir() {
+        // use sharedTempDir
+    }
+
+}
+``` 


### PR DESCRIPTION
Add `@TempDir` annotation usage for JUnit 5, which allows to create and clean up a temporary directory for an individual test or all tests in a test class. 