### PR TITLE
Add metadataExpirationStrategy field to the docs

### DIFF
--- a/docs/user-guide/configuration-files/strongbox-yaml.md
+++ b/docs/user-guide/configuration-files/strongbox-yaml.md
@@ -70,6 +70,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             snapshots:
               id: snapshots
               policy: snapshot
@@ -82,6 +83,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
         storage-common-proxies:
           id: storage-common-proxies
           repositories:
@@ -100,6 +102,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             carlspring:
               id: carlspring
               policy: mixed
@@ -115,6 +118,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             apache-snapshots:
               id: apache-snapshots
               policy: snapshot
@@ -130,6 +134,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             jboss-public-releases:
               id: jboss-public-releases
               policy: release
@@ -145,6 +150,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             maven-oracle:
               id: maven-oracle
               policy: release
@@ -161,6 +167,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             group-common-proxies:
               id: group-common-proxies
               policy: release
@@ -177,6 +184,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             nuget.org:
               id: nuget.org
               policy: release
@@ -202,6 +210,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 downloadRemoteIndexes: true
                 autoBlocking: true
                 checksumValidation: true
+                metadataStrategy: checksum
               repositoryConfiguration:
                 type: Maven 2
                 indexingEnabled: true
@@ -221,6 +230,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             springsource-milestones:
               id: springsource-milestones
               policy: release
@@ -236,6 +246,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             springsource-proxies:
               id: springsource-proxies
               policy: mixed
@@ -251,6 +262,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
         storage-ivy-proxies:
           id: storage-ivy-proxies
           repositories:
@@ -269,6 +281,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             typesafe-ivy-releases:
               id: typesafe-ivy-releases
               policy: release
@@ -284,6 +297,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             group-ivy-proxies:
               id: group-ivy-proxies
               policy: release
@@ -298,6 +312,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
         storage-sbt-proxies:
           id: storage-sbt-proxies
           repositories:
@@ -316,6 +331,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             group-sbt-proxies:
               id: group-sbt-proxies
               policy: release
@@ -330,6 +346,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
         storage-third-party:
           id: storage-third-party
           repositories:
@@ -420,6 +437,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataStrategy: checksum
             nuget-group:
               id: nuget-group
               policy: mixed

--- a/docs/user-guide/configuration-files/strongbox-yaml.md
+++ b/docs/user-guide/configuration-files/strongbox-yaml.md
@@ -70,7 +70,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             snapshots:
               id: snapshots
               policy: snapshot
@@ -83,7 +83,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
         storage-common-proxies:
           id: storage-common-proxies
           repositories:
@@ -102,7 +102,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             carlspring:
               id: carlspring
               policy: mixed
@@ -118,7 +118,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             apache-snapshots:
               id: apache-snapshots
               policy: snapshot
@@ -134,7 +134,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             jboss-public-releases:
               id: jboss-public-releases
               policy: release
@@ -150,7 +150,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             maven-oracle:
               id: maven-oracle
               policy: release
@@ -167,7 +167,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             group-common-proxies:
               id: group-common-proxies
               policy: release
@@ -184,7 +184,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             nuget.org:
               id: nuget.org
               policy: release
@@ -210,11 +210,11 @@ The following is an example of a `strongbox.yaml` configuration file:
                 downloadRemoteIndexes: true
                 autoBlocking: true
                 checksumValidation: true
-                metadataStrategy: checksum
               repositoryConfiguration:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
+                metadataExpirationStrategy: checksum
             springsource-releases:
               id: springsource-releases
               policy: release
@@ -230,7 +230,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             springsource-milestones:
               id: springsource-milestones
               policy: release
@@ -246,7 +246,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             springsource-proxies:
               id: springsource-proxies
               policy: mixed
@@ -262,7 +262,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
         storage-ivy-proxies:
           id: storage-ivy-proxies
           repositories:
@@ -281,7 +281,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             typesafe-ivy-releases:
               id: typesafe-ivy-releases
               policy: release
@@ -297,7 +297,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             group-ivy-proxies:
               id: group-ivy-proxies
               policy: release
@@ -312,7 +312,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
         storage-sbt-proxies:
           id: storage-sbt-proxies
           repositories:
@@ -331,7 +331,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             group-sbt-proxies:
               id: group-sbt-proxies
               policy: release
@@ -346,7 +346,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
         storage-third-party:
           id: storage-third-party
           repositories:
@@ -437,7 +437,7 @@ The following is an example of a `strongbox.yaml` configuration file:
                 type: Maven 2
                 indexingEnabled: true
                 cronExpression: "0 0 2 * * ?"
-                metadataStrategy: checksum
+                metadataExpirationStrategy: checksum
             nuget-group:
               id: nuget-group
               policy: mixed


### PR DESCRIPTION

This is a minor documentation update to reflect the correct attribute name used when configuring the metadata refresh strategy.  More detail is available at https://github.com/strongbox/strongbox/issues/1460