### PR TITLE
Linux containers on windows

### DIFF
--- a/docs/developer-guide/building-the-code-with-docker.md
+++ b/docs/developer-guide/building-the-code-with-docker.md
@@ -8,7 +8,7 @@ We encourage you to have a decent version of Docker installed on your machine
 so that you can debug or reproduce issues easier.
 
 You should note that we are mostly using Linux so this guide is more focused on how to do things on Linux distributions.
-Things under Windows shouldn't be that different, however to use the available images switch to use Linux images in Docker For Windows.
+Things under Windows shouldn't be that different, however for the prebuilt available images make sure your Docker For Windows is using [Linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
 
 ## Docker installation
 

--- a/docs/developer-guide/building-the-code-with-docker.md
+++ b/docs/developer-guide/building-the-code-with-docker.md
@@ -8,7 +8,7 @@ We encourage you to have a decent version of Docker installed on your machine
 so that you can debug or reproduce issues easier.
 
 You should note that we are mostly using Linux so this guide is more focused on how to do things on Linux distributions.
-However, things under Windows shouldn't be that different.
+Things under Windows shouldn't be that different, however to use the available images switch to use Linux images in Docker For Windows.
 
 ## Docker installation
 


### PR DESCRIPTION
While following the guide to run docker-compose on Docker For Windows I noticed an issue that I was using Windows Containers instead of Linux Containers which stop me from using the prebuilt images. I've updated the introduction section to reflect this small consideration under Windows.

Potentially this should be pull out into a separate section if there are more issues under Windows?