### PR TITLE
Issue 1715: Upgrade documentation to mkdocs-material-5.1.0

### DIFF
--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -117,12 +117,12 @@ body > .md-container {
     text-decoration: underline;
 }
 
-
 .md-typeset .task-list-control [type=checkbox]:checked + .task-list-indicator:before {
     color: hsl(200, 86%, 57%);
 }
 
 .md-typeset .task-list-control .task-list-indicator:before {
+    background-color: rgba(255, 255, 255, 0.26);
     color: hsla(200, 86%, 57%, 0.35);
 }
 

--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -126,10 +126,6 @@ body > .md-container {
     color: hsla(200, 86%, 57%, 0.35);
 }
 
-.md-typeset code {
-    box-shadow: 0.29412em 0 0 hsl(207, 24%, 18%), -0.29412em 0 0 hsl(207, 24%, 18%);
-}
-
 .md-typeset code, .md-typeset pre {
     /*background-color: hsl(199, 19%, 39%);*/
     background-color: hsl(207, 24%, 18%);

--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -140,13 +140,9 @@ body > .md-container {
 .md-typeset .codehilite pre,
 .md-typeset .highlight code,
 .md-typeset .highlight pre,
-.md-typeset .superfences-tabs,
-.md-typeset .superfences-content .codehilite {
+.md-typeset .tabbed-set,
+.md-typeset .tabbed-content .codehilite {
     background-color: hsl(207, 24%, 18%);
-}
-
-.md-typeset .superfences-content .codehilite pre {
-    border-top: 1px solid #1f2933;
 }
 
 .md-typeset .codehilitetable .linenodiv, .md-typeset .highlighttable .linenodiv {

--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -145,6 +145,10 @@ body > .md-container {
     background-color: hsl(207, 24%, 18%);
 }
 
+.md-typeset .tabbed-set label {
+    color: rgba(255, 255, 255, 0.9);
+}
+
 .md-typeset .codehilitetable .linenodiv, .md-typeset .highlighttable .linenodiv {
     padding: 0.6rem 0.5rem 0rem 0.5rem;
 }

--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -183,6 +183,7 @@ body > .md-container {
 }
 
 .md-typeset table:not([class]) {
+    background-color: rgba(0,0,0,0.0);
     border: 1px solid rgba(0,0,0,0.3);
 }
 
@@ -201,9 +202,11 @@ body > .md-container {
 
 .md-typeset .md-typeset__table {
     width: 100%;
-    display: block;
-    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
+}
 
+.md-typeset .md-typeset__table table {
+    display: table;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
 }
 
 @media only screen and (max-width: 76.1875em)

--- a/docs/assets/stylesheets/style.css
+++ b/docs/assets/stylesheets/style.css
@@ -132,6 +132,14 @@ body > .md-container {
     color: #f7f7f7;
 }
 
+.md-typeset .codehilitetable .linenos, .md-typeset .highlighttable .linenos {
+    background-color: rgb(35, 47, 57);
+}
+
+.md-typeset .codehilitetable pre, .md-typeset .highlighttable pre {
+    color: rgba(255, 255, 255, 0.26);
+}
+
 .md-typeset .codehilite code,
 .md-typeset .codehilite pre,
 .md-typeset .highlight code,
@@ -143,15 +151,6 @@ body > .md-container {
 
 .md-typeset .tabbed-set label {
     color: rgba(255, 255, 255, 0.9);
-}
-
-.md-typeset .codehilitetable .linenodiv, .md-typeset .highlighttable .linenodiv {
-    padding: 0.6rem 0.5rem 0rem 0.5rem;
-}
-
-.md-typeset .codehilitetable .linenos, .md-typeset .highlighttable .linenos {
-    background-color: rgb(35, 47, 57);
-    color: rgba(255, 255, 255, 0.26);
 }
 
 .md-typeset .footnote,

--- a/docs/developer-guide/building-strongbox-using-strongbox-instance.md
+++ b/docs/developer-guide/building-strongbox-using-strongbox-instance.md
@@ -15,21 +15,22 @@ You can start Strongbox in two ways - via `spring-boot` and from `strongbox-dist
 development phase you will mainly start an instance via `spring-boot`. However once you are done with your task you 
 should always ensure the `strongbox-distribution` package works as expected. 
 
-``` linenums="1" tab="Strongbox via spring-boot"
-git clone {{repo_url}}
-mvn clean install -DskipTests
-cd strongbox-web-core
-mvn spring-boot:run
-```
-
-``` linenums="1" tab="Strongbox from strongbox-distribution"
-git clone {{repo_url}}
-mvn clean install -DskipTests
-cd strongbox-distribution/target
-tar -zxf *gz
-cd strongbox-distribution-*/strongbox-*/
-./bin/strongbox console
-```
+=== "Strongbox via spring-boot"
+    ``` linenums="1"
+    git clone {{repo_url}}
+    mvn clean install -DskipTests
+    cd strongbox-web-core
+    mvn spring-boot:run
+    ```
+=== "Strongbox from strongbox-distribution"
+    ``` linenums="1"
+    git clone {{repo_url}}
+    mvn clean install -DskipTests
+    cd strongbox-distribution/target
+    tar -zxf *gz
+    cd strongbox-distribution-*/strongbox-*/
+    ./bin/strongbox console
+    ```
 
 ## Building and Deploying using Strongbox
 
@@ -38,19 +39,20 @@ Following the steps below should result in successful result:
 1. [Did you pay attention?][Strongbox Instance]
 2. Configure your `settings.xml` to point to the local [Strongbox Instance]:
 
-    ``` tab="Download"
-    # Linux / MacOS
-    curl -o {{localSettingsXml}} \ 
-            {{resources}}/maven/settings-local.xml
-       
-    # Windows
-    curl -o %HOMEPATH%\.m2\settings-local.xml ^
-            {{resources}}/maven/settings-local.xml
-    ``` 
-
-    ``` tab="Raw/Copy" 
-    --8<-- "{{resourcesPath}}/maven/settings-local.xml"
-    ``` 
+    === "Download"
+        ```
+        # Linux / MacOS
+        curl -o {{localSettingsXml}} \ 
+                {{resources}}/maven/settings-local.xml
+           
+        # Windows
+        curl -o %HOMEPATH%\.m2\settings-local.xml ^
+                {{resources}}/maven/settings-local.xml
+        ``` 
+    === "Raw/Copy"
+        ```
+        --8<-- "{{resourcesPath}}/maven/settings-local.xml"
+        ``` 
 
 3. Make a clean clone of @strongbox/strongbox into a separate path (i.e. `strongbox-tmp`)
 4. Build Strongbox using a Strongbox instance:

--- a/docs/developer-guide/building-the-code.md
+++ b/docs/developer-guide/building-the-code.md
@@ -128,7 +128,7 @@ First, you need to have added the original remote (this is a one time only set u
 Then in order to sync your fork with the original remote, execute the following:
 
     git fetch strongbox
-    git checkout master		
+    git checkout master
     git merge strongbox/master
 
 ## See Also

--- a/docs/developer-guide/getting-started.md
+++ b/docs/developer-guide/getting-started.md
@@ -20,17 +20,17 @@ Please, place this [settings.xml]({{resources}}/maven/settings.xml) file under y
 We have dependencies which are only available through our repository and if you skip this it will cause build failure.
 
 === "Linux"
-	``` linenums="1"
-	mkdir ~/.m2
-	curl -o ~/.m2/settings.xml \
-	        {{resources}}/maven/settings.xml
-	```
+    ``` linenums="1"
+    mkdir ~/.m2
+    curl -o ~/.m2/settings.xml \
+            {{resources}}/maven/settings.xml
+    ```
 === "Windows"
-	``` linenums="1"
-	mkdir %HOMEPATH%\.m2
-	curl -o %HOMEPATH%\.m2\settings.xml ^
-	        {{resources}}/maven/settings.xml
-	```
+    ``` linenums="1"
+    mkdir %HOMEPATH%\.m2
+    curl -o %HOMEPATH%\.m2\settings.xml ^
+            {{resources}}/maven/settings.xml
+    ```
 
 !!! tip
     You can use a different location to save our `settings.xml`. For example, you could save it as   

--- a/docs/developer-guide/getting-started.md
+++ b/docs/developer-guide/getting-started.md
@@ -11,17 +11,18 @@
 Please, place this [settings.xml]({{resources}}/maven/settings.xml) file under your `~/.m2` directory.
 We have dependencies which are only available through our repository and if you skip this it will cause build failure.
 
-```Linux tab= linenums="1"
-mkdir ~/.m2
-curl -o ~/.m2/settings.xml \
-        {{resources}}/maven/settings.xml
-```
-
-```Windows tab= linenums="1"
-mkdir %HOMEPATH%\.m2
-curl -o %HOMEPATH%\.m2\settings.xml ^
-        {{resources}}/maven/settings.xml
-```
+=== "Linux"
+	``` linenums="1"
+	mkdir ~/.m2
+	curl -o ~/.m2/settings.xml \
+	        {{resources}}/maven/settings.xml
+	```
+=== "Windows"
+	``` linenums="1"
+	mkdir %HOMEPATH%\.m2
+	curl -o %HOMEPATH%\.m2\settings.xml ^
+	        {{resources}}/maven/settings.xml
+	```
 
 !!! tip
     You can use a different location to save our `settings.xml`. For example, you could save it as   

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -19,143 +19,143 @@ In order to run Strongbox you need to have a machine with minimum:
 <a href="https://github.com/strongbox/strongbox/releases" target="_blank">Download strongbox</a>
 
 === "Linux (tar)"
-	```linuxtar linenums="1"
-	# Open a terminal
+    ```linuxtar linenums="1"
+    # Open a terminal
 
-	sudo su
+    sudo su
 
-	mkdir /opt/strongbox /opt/strongbox-vault
+    mkdir /opt/strongbox /opt/strongbox-vault
 
-	groupadd strongbox
-	useradd -d /opt/strongbox -g strongbox -r strongbox
+    groupadd strongbox
+    useradd -d /opt/strongbox -g strongbox -r strongbox
 
-	chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
+    chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
 
-	chmod -R 770 /opt/strongbox /opt/strongbox-vault
+    chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
-	su strongbox
-	tar -zxf /path/to/strongbox-distribution*.tar.gz \
-	    -C /opt/strongbox \ 
-	    --strip-components=2
+    su strongbox
+    tar -zxf /path/to/strongbox-distribution*.tar.gz \
+        -C /opt/strongbox \ 
+        --strip-components=2
 
-	# If you just want to start Strongbox without installing the systemd service:
+    # If you just want to start Strongbox without installing the systemd service:
 
-	/opt/strongbox/bin/strongbox console
+    /opt/strongbox/bin/strongbox console
 
-	# If you want to install Strongbox as a service then download the 
-	# systemd service file. Make sure to change the `Environment` variables 
-	# in the service file where necessary. Depending on your distribution, 
-	# you could also move the environment variables into `EnvironmentFile` 
-	# and load that instead.
+    # If you want to install Strongbox as a service then download the 
+    # systemd service file. Make sure to change the `Environment` variables 
+    # in the service file where necessary. Depending on your distribution, 
+    # you could also move the environment variables into `EnvironmentFile` 
+    # and load that instead.
 
-	sudo curl -o /etc/systemd/system/strongbox.service \
-	     {{resources}}/systemd/strongbox.service 
-	sudo systemctl deamon-reload
-	sudo service strongbox start
+    sudo curl -o /etc/systemd/system/strongbox.service \
+         {{resources}}/systemd/strongbox.service 
+    sudo systemctl deamon-reload
+    sudo service strongbox start
 
-	# this step is optional: only if you want to start Strongbox at boot!
-	sudo systemctl enable strongbox
-	```
+    # this step is optional: only if you want to start Strongbox at boot!
+    sudo systemctl enable strongbox
+    ```
 === "Linux (RPM)"
-	```linuxrpm linenums="1"
-	# Open a terminal
+    ```linuxrpm linenums="1"
+    # Open a terminal
 
-	# First, make sure you have a JRE with version 1.8
-	# installed on your system.  You can use your favorite package manager
-	# to find one.
+    # First, make sure you have a JRE with version 1.8
+    # installed on your system.  You can use your favorite package manager
+    # to find one.
 
-	sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
+    sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
 
-	# If you just want to start Strongbox without installing the systemd service:
-	su strongbox
-	/opt/strongbox/bin/strongbox console
+    # If you just want to start Strongbox without installing the systemd service:
+    su strongbox
+    /opt/strongbox/bin/strongbox console
 
-	# If you want to configure strongbox to start at system, boot:
+    # If you want to configure strongbox to start at system, boot:
 
-	sudo systemctl enable strongbox.service
-	sudo service strongbox start
+    sudo systemctl enable strongbox.service
+    sudo service strongbox start
 
-	```
+    ```
 === "Linux (deb)"
-	```linuxdeb linenums="1"
-	# Open a terminal
+    ```linuxdeb linenums="1"
+    # Open a terminal
 
-	# First, make sure you have a JRE with version 1.8
-	# installed on your system.  You can use your favorite package manager
-	# to find one.
+    # First, make sure you have a JRE with version 1.8
+    # installed on your system.  You can use your favorite package manager
+    # to find one.
 
-	# Install:
-	sudo dpkg -i /path/to/strongbox-*.deb
+    # Install:
+    sudo dpkg -i /path/to/strongbox-*.deb
 
-	# If you just want to start Strongbox without installing the systemd service:
-	su strongbox
-	/opt/strongbox/bin/strongbox console
+    # If you just want to start Strongbox without installing the systemd service:
+    su strongbox
+    /opt/strongbox/bin/strongbox console
 
-	# If you want to configure strongbox to start at system, boot:
-	sudo systemctl enable strongbox
-	sudo systemctl start strongbox
+    # If you want to configure strongbox to start at system, boot:
+    sudo systemctl enable strongbox
+    sudo systemctl start strongbox
 
-	# Remove the package:
-	sudo dpkg -r strongbox
+    # Remove the package:
+    sudo dpkg -r strongbox
 
-	# Purge configuration files, note this does not remove strongbox-vault:
-	sudo dpkg -P strongbox
+    # Purge configuration files, note this does not remove strongbox-vault:
+    sudo dpkg -P strongbox
 
-	```
+    ```
 === "Windows"
-	``` linenums="1"
-	# Unzip the distribution.
+    ``` linenums="1"
+    # Unzip the distribution.
 
-	# To start Strongbox, run cmd or PowerShell and execute:
-	c:\java\strongbox> bin\strongbox.bat console
-	      wrapper   | Strongbox: Distribution started...
+    # To start Strongbox, run cmd or PowerShell and execute:
+    c:\java\strongbox> bin\strongbox.bat console
+          wrapper   | Strongbox: Distribution started...
 
-	# To install Strongbox as a service, run cmd or PowerShell and execute:
-	c:\java\strongbox> bin\strongbox.bat install
-	      wrapper  | Strongbox: Distribution installed.
-	c:\java\strongbox> bin\strongbox.bat start
+    # To install Strongbox as a service, run cmd or PowerShell and execute:
+    c:\java\strongbox> bin\strongbox.bat install
+          wrapper  | Strongbox: Distribution installed.
+    c:\java\strongbox> bin\strongbox.bat start
 
-	```
+    ```
 === "MacOS"
-	``` linenums="1"
-	# Open a terminal
+    ``` linenums="1"
+    # Open a terminal
 
-	sudo su
-	sysadminctl -addUser strongbox
+    sudo su
+    sysadminctl -addUser strongbox
 
-	mkdir -p /opt/strongbox /opt/strongbox-vault
+    mkdir -p /opt/strongbox /opt/strongbox-vault
 
-	chown -R strongbox:staff /opt/strongbox /opt/strongbox-vault
+    chown -R strongbox:staff /opt/strongbox /opt/strongbox-vault
 
-	chmod -R 770 /opt/strongbox /opt/strongbox-vault
+    chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
-	su strongbox
-	tar -zxf /path/to/strongbox-distribution*.tar.gz \
-	    -C /opt/strongbox \ 
-	    --strip-components=2
+    su strongbox
+    tar -zxf /path/to/strongbox-distribution*.tar.gz \
+        -C /opt/strongbox \ 
+        --strip-components=2
 
-	# If you just want to start Strongbox without installing the launchctl service:
+    # If you just want to start Strongbox without installing the launchctl service:
 
-	/opt/strongbox/bin/strongbox console
+    /opt/strongbox/bin/strongbox console
 
-	# If you want to install Strongbox as a LaunchDaemon then download the 
-	# plist file. If you've customized the installation, edit the details
-	# in the plist file where necessary.
-	# (This file must be owned by root.)
-	sudo curl -o /Library/LaunchDaemons/strongbox.plist \
-	     {{resources}}/launchctl/strongbox.plist
+    # If you want to install Strongbox as a LaunchDaemon then download the 
+    # plist file. If you've customized the installation, edit the details
+    # in the plist file where necessary.
+    # (This file must be owned by root.)
+    sudo curl -o /Library/LaunchDaemons/strongbox.plist \
+         {{resources}}/launchctl/strongbox.plist
 
-	# This will validate that launchd can load the file and start the service.
-	sudo launchctl load /opt/strongbox/etc/strongbox.plist
+    # This will validate that launchd can load the file and start the service.
+    sudo launchctl load /opt/strongbox/etc/strongbox.plist
 
-	# Strongbox will now start on boot.
+    # Strongbox will now start on boot.
 
-	```
+    ```
 === "Docker"
-	``` linenums="1"
-	Currently unavailable due to our heavy development.
-	We are planning to start releasing to hub.docker.com very soon.
+    ``` linenums="1"
+    Currently unavailable due to our heavy development.
+    We are planning to start releasing to hub.docker.com very soon.
 
-	Meanwhile, you could clone strongbox/strongbox 
-	use `docker-compose up` instead.
-	```
+    Meanwhile, you could clone strongbox/strongbox 
+    use `docker-compose up` instead.
+    ```

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -10,149 +10,144 @@
 
 <a href="https://github.com/strongbox/strongbox/releases" target="_blank">Download strongbox</a>
 
-```linuxtar linenums="1" tab="Linux (tar)"
-# Open a terminal
+=== "Linux (tar)"
+	```linuxtar linenums="1"
+	# Open a terminal
 
-sudo su
+	sudo su
 
-mkdir /opt/strongbox /opt/strongbox-vault
+	mkdir /opt/strongbox /opt/strongbox-vault
 
-groupadd strongbox
-useradd -d /opt/strongbox -g strongbox -r strongbox
+	groupadd strongbox
+	useradd -d /opt/strongbox -g strongbox -r strongbox
 
-chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
+	chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
 
-chmod -R 770 /opt/strongbox /opt/strongbox-vault
+	chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
-su strongbox
-tar -zxf /path/to/strongbox-distribution*.tar.gz \
-    -C /opt/strongbox \ 
-    --strip-components=2
+	su strongbox
+	tar -zxf /path/to/strongbox-distribution*.tar.gz \
+	    -C /opt/strongbox \ 
+	    --strip-components=2
 
-# If you just want to start Strongbox without installing the systemd service:
+	# If you just want to start Strongbox without installing the systemd service:
 
-/opt/strongbox/bin/strongbox console
+	/opt/strongbox/bin/strongbox console
 
-# If you want to install Strongbox as a service then download the 
-# systemd service file. Make sure to change the `Environment` variables 
-# in the service file where necessary. Depending on your distribution, 
-# you could also move the environment variables into `EnvironmentFile` 
-# and load that instead.
+	# If you want to install Strongbox as a service then download the 
+	# systemd service file. Make sure to change the `Environment` variables 
+	# in the service file where necessary. Depending on your distribution, 
+	# you could also move the environment variables into `EnvironmentFile` 
+	# and load that instead.
 
-sudo curl -o /etc/systemd/system/strongbox.service \
-     {{resources}}/systemd/strongbox.service 
-sudo systemctl deamon-reload
-sudo service strongbox start
+	sudo curl -o /etc/systemd/system/strongbox.service \
+	     {{resources}}/systemd/strongbox.service 
+	sudo systemctl deamon-reload
+	sudo service strongbox start
 
-# this step is optional: only if you want to start Strongbox at boot!
-sudo systemctl enable strongbox
-```
+	# this step is optional: only if you want to start Strongbox at boot!
+	sudo systemctl enable strongbox
+	```
+=== "Linux (RPM)"
+	```linuxrpm linenums="1"
+	# Open a terminal
 
-```linuxrpm linenums="1" tab="Linux (RPM)"
-# Open a terminal
+	# First, make sure you have a JRE with version 1.8
+	# installed on your system.  You can use your favorite package manager
+	# to find one.
 
-# First, make sure you have a JRE with version 1.8
-# installed on your system.  You can use your favorite package manager
-# to find one.
+	sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
 
-sudo rpm -ivh /path/to/strongbox-distribution-*.rpm
+	# If you just want to start Strongbox without installing the systemd service:
+	su strongbox
+	/opt/strongbox/bin/strongbox console
 
-# If you just want to start Strongbox without installing the systemd service:
-su strongbox
-/opt/strongbox/bin/strongbox console
+	# If you want to configure strongbox to start at system, boot:
 
-# If you want to configure strongbox to start at system, boot:
+	sudo systemctl enable strongbox.service
+	sudo service strongbox start
 
-sudo systemctl enable strongbox.service
-sudo service strongbox start
+	```
+=== "Linux (deb)"
+	```linuxdeb linenums="1"
+	# Open a terminal
 
-```
+	# First, make sure you have a JRE with version 1.8
+	# installed on your system.  You can use your favorite package manager
+	# to find one.
 
+	# Install:
+	sudo dpkg -i /path/to/strongbox-*.deb
 
-```linuxdeb linenums="1" tab="Linux (deb)"
-# Open a terminal
+	# If you just want to start Strongbox without installing the systemd service:
+	su strongbox
+	/opt/strongbox/bin/strongbox console
 
-# First, make sure you have a JRE with version 1.8
-# installed on your system.  You can use your favorite package manager
-# to find one.
+	# If you want to configure strongbox to start at system, boot:
+	sudo systemctl enable strongbox
+	sudo systemctl start strongbox
 
-# Install:
-sudo dpkg -i /path/to/strongbox-*.deb
+	# Remove the package:
+	sudo dpkg -r strongbox
 
-# If you just want to start Strongbox without installing the systemd service:
-su strongbox
-/opt/strongbox/bin/strongbox console
+	# Purge configuration files, note this does not remove strongbox-vault:
+	sudo dpkg -P strongbox
 
-# If you want to configure strongbox to start at system, boot:
-sudo systemctl enable strongbox
-sudo systemctl start strongbox
+	```
+=== "Windows"
+	``` linenums="1"
+	# Unzip the distribution.
 
-# Remove the package:
-sudo dpkg -r strongbox
+	# To start Strongbox, run cmd or PowerShell and execute:
+	c:\java\strongbox> bin\strongbox.bat console
+	      wrapper   | Strongbox: Distribution started...
 
-# Purge configuration files, note this does not remove strongbox-vault:
-sudo dpkg -P strongbox
+	# To install Strongbox as a service, run cmd or PowerShell and execute:
+	c:\java\strongbox> bin\strongbox.bat install
+	      wrapper  | Strongbox: Distribution installed.
+	c:\java\strongbox> bin\strongbox.bat start
 
-```
+	```
+=== "MacOS"
+	``` linenums="1"
+	# Open a terminal
 
+	sudo su
+	sysadminctl -addUser strongbox
 
-```Windows linenums="1" tab=
+	mkdir -p /opt/strongbox /opt/strongbox-vault
 
-# Unzip the distribution.
+	chown -R strongbox:staff /opt/strongbox /opt/strongbox-vault
 
-# To start Strongbox, run cmd or PowerShell and execute:
-c:\java\strongbox> bin\strongbox.bat console
-      wrapper   | Strongbox: Distribution started...
+	chmod -R 770 /opt/strongbox /opt/strongbox-vault
 
-# To install Strongbox as a service, run cmd or PowerShell and execute:
-c:\java\strongbox> bin\strongbox.bat install
-      wrapper  | Strongbox: Distribution installed.
-c:\java\strongbox> bin\strongbox.bat start
+	su strongbox
+	tar -zxf /path/to/strongbox-distribution*.tar.gz \
+	    -C /opt/strongbox \ 
+	    --strip-components=2
 
-```
+	# If you just want to start Strongbox without installing the launchctl service:
 
-```MacOS linenums="1" tab=
-# Open a terminal
+	/opt/strongbox/bin/strongbox console
 
-sudo su
-sysadminctl -addUser strongbox
+	# If you want to install Strongbox as a LaunchDaemon then download the 
+	# plist file. If you've customized the installation, edit the details
+	# in the plist file where necessary.
+	# (This file must be owned by root.)
+	sudo curl -o /Library/LaunchDaemons/strongbox.plist \
+	     {{resources}}/launchctl/strongbox.plist
 
-mkdir -p /opt/strongbox /opt/strongbox-vault
+	# This will validate that launchd can load the file and start the service.
+	sudo launchctl load /opt/strongbox/etc/strongbox.plist
 
-chown -R strongbox:staff /opt/strongbox /opt/strongbox-vault
+	# Strongbox will now start on boot.
 
-chmod -R 770 /opt/strongbox /opt/strongbox-vault
+	```
+=== "Docker"
+	``` linenums="1"
+	Currently unavailable due to our heavy development.
+	We are planning to start releasing to hub.docker.com very soon.
 
-su strongbox
-tar -zxf /path/to/strongbox-distribution*.tar.gz \
-    -C /opt/strongbox \ 
-    --strip-components=2
-
-# If you just want to start Strongbox without installing the launchctl service:
-
-/opt/strongbox/bin/strongbox console
-
-# If you want to install Strongbox as a LaunchDaemon then download the 
-# plist file. If you've customized the installation, edit the details
-# in the plist file where necessary.
-# (This file must be owned by root.)
-sudo curl -o /Library/LaunchDaemons/strongbox.plist \
-     {{resources}}/launchctl/strongbox.plist
-
-# This will validate that launchd can load the file and start the service.
-sudo launchctl load /opt/strongbox/etc/strongbox.plist
-
-# Strongbox will now start on boot.
-
-```
-
-```Docker linenums="1" tab=
-
-Currently unavailable due to our heavy development.
-We are planning to start releasing to hub.docker.com very soon.
-
-Meanwhile, you could clone strongbox/strongbox 
-use `docker-compose up` instead.
-```
-
-
+	Meanwhile, you could clone strongbox/strongbox 
+	use `docker-compose up` instead.
+	```

--- a/docs/user-guide/tool-integration/nuget-chocolatey-example.md
+++ b/docs/user-guide/tool-integration/nuget-chocolatey-example.md
@@ -12,8 +12,6 @@ The "Hello, Strongbox!" example project can be found [here][hello-strongbox-nuge
 
 ## Installing choco
 
-<!-- todo: pymdownx.tabbed -->
-
 !!! success "Windows"
     Chocolatey is available natively on Windows and can be installed following the [official documentation]
 

--- a/docs/user-guide/tool-integration/nuget-chocolatey-example.md
+++ b/docs/user-guide/tool-integration/nuget-chocolatey-example.md
@@ -34,16 +34,17 @@ It is OK to ignore warnings about a system reboot being requested since the noth
 
 The NuGet protocol assumes that users need to be authenticated with `API Key` to be able to deploy or delete your packages.
 Strongbox provides the REST API to get an API Key for specified user:
-    
-``` tab="Windows" linenums="1"
-FOR /F %i IN ('curl -u admin http://localhost:48080/api/users/admin/generate-security-token') DO set API_KEY=%i
-echo %API_KEY%
-```
 
-``` tab="Linux" linenums="1"
-API_KEY=`curl -u admin http://localhost:48080/api/users/admin/generate-security-token`
-echo $API_KEY
-```
+=== "Windows"
+    ``` linenums="1"
+    FOR /F %i IN ('curl -u admin http://localhost:48080/api/users/admin/generate-security-token') DO set API_KEY=%i
+    echo %API_KEY%
+    ```
+=== "Linux"
+    ``` linenums="1"
+    API_KEY=`curl -u admin http://localhost:48080/api/users/admin/generate-security-token`
+    echo $API_KEY
+    ```
 
 Enter your Strongbox password. (Default is: `admin/password`)
 
@@ -55,16 +56,17 @@ The output when `echo`ing the `%API_KEY%` should not be empty and should look so
 
 In this step, we will be setting the `apikey` which will be used to authenticate against the `source` in the future steps.
 
-``` tab="Windows" linenums="1"
-# This needs to be run in an administrative command prompt or powershell!
-set REPO_URL=http://localhost:48080/storages/storage-nuget/nuget-releases
-choco apikey -k %API_KEY% -s "%REPO_URL%"
-```
-
-``` tab="Linux" linenums="1"
-REPO_URL=http://localhost:48080/storages/storage-nuget/nuget-releases
-choco apikey -k $API_KEY -s "$REPO_URL"
-```
+=== "Windows"
+    ``` linenums="1"
+    # This needs to be run in an administrative command prompt or powershell!
+    set REPO_URL=http://localhost:48080/storages/storage-nuget/nuget-releases
+    choco apikey -k %API_KEY% -s "%REPO_URL%"
+    ```
+=== "Linux"
+    ``` linenums="1"
+    REPO_URL=http://localhost:48080/storages/storage-nuget/nuget-releases
+    choco apikey -k $API_KEY -s "$REPO_URL"
+    ```
 
 The output should be like follows:
 
@@ -77,14 +79,15 @@ Added ApiKey for http://localhost:48080/storages/storage-nuget/nuget-releases
 
 To manage packages, you'll need to configure Chocolatey to access your storages by running the following command:
 
-``` tab="Windows" linenums="1"
-# This needs to be run as administrative command prompt or powershell!
-choco source add -n=strongbox -s "%REPO_URL%" --priority=1
-``` 
-
-``` tab="Linux" linenums="1"
-choco source add -n=strongbox -s "$REPO_URL" --priority=1
-```
+=== "Windows"
+    ``` linenums="1"
+    # This needs to be run as administrative command prompt or powershell!
+    choco source add -n=strongbox -s "%REPO_URL%" --priority=1
+    ``` 
+=== "Linux"
+    ``` linenums="1"
+    choco source add -n=strongbox -s "$REPO_URL" --priority=1
+    ```
 
 The output should be like follows:
 
@@ -103,15 +106,16 @@ Added strongbox - http://localhost:48080/storages/storage-nuget/nuget-releases (
 
 ### Create a package
 
-``` tab="Windows" linenums="1"
-cd C:\some\path
-choco new --name=hello-chocolatey --version=1.0.0
-``` 
-
-``` tab="Linux" linenums="1"
-cd /some/path
-choco new --name=hello-chocolatey --version=1.0.0
-```
+=== "Windows"
+    ``` linenums="1"
+    cd C:\some\path
+    choco new --name=hello-chocolatey --version=1.0.0
+    ``` 
+=== "Linux"
+    ``` linenums="1"
+    cd /some/path
+    choco new --name=hello-chocolatey --version=1.0.0
+    ```
 
 The output should be like
 
@@ -158,15 +162,16 @@ Successfully generated hello-chocolatey package specification files
 
 Execute the following command in the same directory as `hello-chocolatey.nuspec`:
 
-``` tab="Windows" linenums="1"
-cd C:\some\path\hello-chocolatey
-choco pack
-``` 
-
-``` tab="Linux" linenums="1"
-cd /some/path/to/hello-chocolatey
-choco pack
-```
+=== "Windows"
+    ``` linenums="1"
+    cd C:\some\path\hello-chocolatey
+    choco pack
+    ``` 
+=== "Linux"
+    ``` linenums="1"
+    cd /some/path/to/hello-chocolatey
+    choco pack
+    ```
 
 The output should be like follows:
 ```log
@@ -181,15 +186,17 @@ Successfully created package 'C:\Users\User\Documents\hello-chocolatey\hello-cho
 
 Execute the following command in the directory with `hello-chocolatey.1.0.0.nupkg`:
 
-``` tab="Windows" linenums="1"
-cd C:\some\path\hello-chocolatey
-choco push --source "%REPO_URL%" --force
-``` 
+=== "Windows"
+    ``` linenums="1"
+    cd C:\some\path\hello-chocolatey
+    choco push --source "%REPO_URL%" --force
+    ``` 
 
-``` tab="Linux" linenums="1"
-cd /some/path/to/hello-chocolatey
-choco push --source "$REPO_URL" --force
-```
+=== "Linux"
+    ``` linenums="1"
+    cd /some/path/to/hello-chocolatey
+    choco push --source "$REPO_URL" --force
+    ```
 
 The output should be like follows:
 ```log
@@ -204,13 +211,14 @@ hello-chocolatey 1.0.0 was pushed successfully to http://localhost:48080/storage
 
 Execute the following command:
 
-``` tab="Windows" linenums="1"
-choco search -s "%REPO_URL%"
-``` 
-
-``` tab="Linux" linenums="1"
-choco search -s "$REPO_URL"
-```
+=== "Windows"
+    ``` linenums="1"
+    choco search -s "%REPO_URL%"
+    ``` 
+=== "Linux"
+    ``` linenums="1"
+    choco search -s "$REPO_URL"
+    ```
 
 The output should be like follows:
 ```log
@@ -230,14 +238,15 @@ As a workaround, you can use `nuget` to delete packages, see [hello-strongbox-nu
 
 To install a `choco` package you should use the command below. 
 
-``` tab="Windows" linenums="1"
-# Execute the following command as a administrator!
-choco install hello-chocolatey -s "%REPO_URL%"
-```
-
-``` tab="Linux" linenums="1"
-choco install hello-chocolatey -s "$REPO_URL"
-```
+=== "Windows"
+    ``` linenums="1"
+    # Execute the following command as a administrator!
+    choco install hello-chocolatey -s "%REPO_URL%"
+    ```
+=== "Linux"
+    ``` linenums="1"
+    choco install hello-chocolatey -s "$REPO_URL"
+    ```
 
 !!! tip "Tip"
     Adding `-s "{repo_url}"` is optional. However, `choco` will loop through all sources until it finds the package which
@@ -267,14 +276,15 @@ Chocolatey installed 1/1 packages.
 
 ### Uninstall a package
 
-``` tab="Windows" linenums="1"
-# Execute the following command as a administrator!
-choco uninstall hello-chocolatey
-```
-
-``` tab="Linux" linenums="1"
-choco uninstall hello-chocolatey
-```
+=== "Windows"
+    ``` linenums="1"
+    # Execute the following command as a administrator!
+    choco uninstall hello-chocolatey
+    ```
+=== "Linux"
+    ``` linenums="1"
+    choco uninstall hello-chocolatey
+    ```
 
 The output should be like follows:
 ```log

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,8 @@ theme:
     primary: 'blue grey'
     accent: 'indigo'
   language: en
-  feature:
-    tabs: true
+  features:
+    - tabs
 
 extra_css:
   - 'assets/stylesheets/style.css'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: docs
   - pymdownx.superfences
+  - pymdownx.tabbed
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==4.4.2
+mkdocs-material==5.1.0
 mkdocs-markdownextradata-plugin
 mkdocs-git-revision-date-plugin
 mdx_gh_links

--- a/theme/main.html
+++ b/theme/main.html
@@ -2,9 +2,4 @@
 
 {% block content %}
     {{super()}}
-
-    {% if page.meta.revision_date %}
-        <small><br><i>Last updated {{ page.meta.revision_date }}</i></small>
-    {% endif %}
-
 {% endblock %}


### PR DESCRIPTION
# Description

Fixes https://github.com/strongbox/strongbox/issues/1715

- Version changed from 4.4.2 to 5.1.0 in requirements.txt
- mkdocs.yml updated per [Upgrading to 5.x](https://squidfunk.github.io/mkdocs-material/releases/5/)
- pymdownx.tabbed dependecy added
- Tabs migrated from [superfences-tabs](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#tabbed-fences) to [pymdownx.tabbed](https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/)
- Removed git-revision-date from base.html (managed by mkdocs-material since 4.6.0)
- Fixed deprecated CSS styling for tabs, tables, tasklists, and code blocks

Docker image also needs to be upgraded, see https://github.com/strongbox/ci-build-images/pull/9